### PR TITLE
Add basic view class

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,26 +2,20 @@ import pygame
 from pygame import *
 
 from board import Board
-
-DISPLAY_WIDTH = 700
-DISPLAY_HEIGHT = 600
-WIDTH = 7
-HEIGHT = 6
+from view import View
 
 pygame.init()
 
-DISP = display.set_mode((DISPLAY_WIDTH, DISPLAY_HEIGHT))
-display.set_caption("Connect 4 Recursive")
+WIDTH = 7
+HEIGHT = 6
 
-# testing board class
-board = Board(WIDTH, HEIGHT, 2)
-print(board)
-print(board.chips)
-print(board.sub_boards)
+board = Board(WIDTH, HEIGHT, 1, 4)
+view = View(WIDTH, HEIGHT)
+view.render_board(board)
 
 running = True
 while running:
   for event in pygame.event.get():
     if event.type == QUIT:
       running = False
-      
+      break

--- a/view.py
+++ b/view.py
@@ -1,0 +1,52 @@
+from pygame import *
+from pyautogui import size as screen_size
+
+from board import Board
+
+from random import randint
+
+class View:
+  DEFAULT_CHIP_SIZE = 100
+  BORDER_PROPORTION = 0.1  # proportion of chip size put between chips
+
+  DARK_BLUE = (20, 0, 75)
+  BLUE = (40, 90, 155)
+  RED = (170, 30, 30)
+  GREEN = (0, 200, 0)
+  YELLOW = (230, 210, 40)
+  LIGHT_GREY = (100, 100, 100)
+  
+  COLOUR_MAP = {
+    Board.NOT_COMPLETE: BLUE,
+    Board.PLAYER_ONE: RED,
+    Board.PLAYER_TWO: YELLOW,
+    Board.DRAW: LIGHT_GREY,
+  }
+
+  def __init__(self, columns: int, rows: int):
+    self.COLUMNS = columns
+    self.ROWS = rows
+    self.CHIP_SIZE = self.chip_size(columns, rows)
+    self.CHIP_WITH_BORDER_SIZE = self.CHIP_SIZE * (1 + self.BORDER_PROPORTION)
+    self.DISPLAY_WIDTH = columns * self.CHIP_WITH_BORDER_SIZE
+    self.DISPLAY_HEIGHT = rows * self.CHIP_WITH_BORDER_SIZE
+    self.screen = display.set_mode((self.DISPLAY_WIDTH, self.DISPLAY_HEIGHT))
+    display.set_caption("Connect Recursive")
+    self.screen.fill(self.DARK_BLUE)
+
+  def chip_size(self, columns: int, rows: int):
+    width, height = screen_size()
+    width_max_chip_size = (width - 100) // (columns * (1 + self.BORDER_PROPORTION))
+    height_max_chip_size = (height - 100) // (rows * (1 + self.BORDER_PROPORTION))
+    return min(self.DEFAULT_CHIP_SIZE, width_max_chip_size, height_max_chip_size)
+
+  def render_board(self, board: Board):
+    for i in range(self.COLUMNS):
+      for j in range(self.ROWS):
+        draw.circle(
+          self.screen,
+          self.COLOUR_MAP[board.chips[i][j]],
+          ((i + 0.5) * self.CHIP_WITH_BORDER_SIZE, (self.ROWS - j - 0.5) * self.CHIP_WITH_BORDER_SIZE),
+          self.CHIP_SIZE // 2,
+        )
+    display.update()


### PR DESCRIPTION
The `View` class contains constants and functionality relevant to displaying a `Board` using a Pygame display. If the chosen default chip size is too large to fit on the screen, the window is resized to match the physical dimensions of the user's screen.

---

![image](https://github.com/user-attachments/assets/0cb29d05-4b5b-4af7-9c88-63006f265bf5)
